### PR TITLE
Implemented FXAA anti-aliasing as a compute post-process pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Configure (first time only)
 "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -B build -G "Visual Studio 18 2026" -A x64
 
-# Build (Release)
-"C:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\Bin\amd64\MSBuild.exe" build\Engine.vcxproj /p:Configuration=Release /p:Platform=x64 /m /v:minimal
+# Build (Release) — use -p: instead of /p: under Git Bash; leading slashes get path-mangled
+"C:/Program Files/Microsoft Visual Studio/18/Community/MSBuild/Current/Bin/amd64/MSBuild.exe" build/Engine.vcxproj -p:Configuration=Release -p:Platform=x64 -m -v:minimal
 
 # Run
 build\Release\Engine.exe
@@ -38,7 +38,8 @@ This is a **Triangle Splatting** renderer — a compute-shader-only rendering en
 | 2: Bin | `pass3_bin.comp` | Scatter triangle IDs into per-tile lists using prefix-sum offsets |
 | 3: Rasterize | `pass4_rasterize_tiled.comp` | Per-pixel edge tests, depth/normal/position interpolation, Blinn-Phong or PBR shading, WBOIT accumulation for transparent fragments |
 | 4: OIT Composite | `pass5_oit_composite.comp` | Blend the weighted transparent layer over the opaque output image |
-| 5: Display | ImGui viewport | Sample output texture and present |
+| 5: FXAA | `pass6_fxaa.comp` | Post-process anti-aliasing; samples `outputImage`, writes `presentationImage`. Skipped when `m_fxaaEnabled` is false |
+| 6: Display | ImGui viewport | Sample `getDisplayTexture()` (presentation if FXAA on, else output) and present |
 
 ### Transparency System (WBOIT)
 
@@ -75,7 +76,7 @@ Synchronous pub/sub via `EventBus.h/cpp`:
 | TextureManager | `TextureManager.h/cpp` | Owns the `GL_TEXTURE_2D_ARRAY` sampled in pass4 as `textureAtlas` |
 | TileRasterizer | `TileRasterizer.h/cpp` | Allocates/resizes the 6 tiling pipeline SSBOs; handles prefix-sum CPU readback |
 | COFFParser | `COFFParser.h/cpp` | Loads OFF/COFF files, computes smooth per-vertex normals (area-weighted), generates planar UVs |
-| ComputeShader | `ComputeShader.h/cpp` | Loads `.comp` files; uniform API: `setInt/UInt/Float/Vec3/IVec2/Mat4` |
+| ComputeShader | `ComputeShader.h/cpp` | Loads `.comp` files; uniform API: `setInt/UInt/Float/Vec3/IVec2/Mat4` — **no `setVec2`**; pass screen-size as `ivec2` and compute `1.0/vec2(screenSize)` in the shader |
 | AssetManager | `AssetManager.h/cpp` | Mesh loading, caching, ref-counting, async support |
 | Entity | `Entity.h` | Transform + optional mesh + optional `Light` (`std::optional<Light>`) |
 | Camera | `Camera.h/cpp` | FPS 6DOF (quaternion), orbit mode, bookmarks |
@@ -106,6 +107,13 @@ Synchronous pub/sub via `EventBus.h/cpp`:
 | 2 | TileOffsetBuffer |
 | 3 | TriangleListBuffer |
 | 4 | TileWriteOffsetBuffer |
+
+### pass6_fxaa.comp
+Uses no SSBOs. Sampler texture units and image units are separate namespaces, so `binding = 0` is used on both without conflict.
+| Binding | Type | Buffer/Image |
+|---------|------|-------------|
+| sampler unit 0 | `sampler2D` (RGBA32F) | srcImage — bound to `m_outputTexture`, bilinear fetches |
+| image unit 0   | `image2D` (RGBA32F)   | dstImage — bound to `m_presentationTexture`, write-only |
 
 ### pass4_rasterize_tiled.comp + pass5_oit_composite.comp
 | Binding | Type | Buffer/Image |
@@ -152,6 +160,7 @@ Image units and SSBO binding points are **separate namespaces**. `GL_MAX_IMAGE_U
 
 - **Rasterization / shading / transparency:** `pass4_rasterize_tiled.comp` (opaque + WBOIT accumulation)
 - **OIT compositing formula:** `pass5_oit_composite.comp`
+- **FXAA tuning:** `pass6_fxaa.comp` (edge thresholds, subpixel blend). Runtime state lives on `Renderer` (`m_fxaaEnabled`, `m_fxaaQualitySubpix`, `m_fxaaEdgeThreshold`, `m_fxaaEdgeThresholdMin`)
 - **Material parameters (CPU side):** `Mesh.h` (`GPUMaterial`), `MaterialManager.cpp` (defaults)
 - **Material UI:** search `ImGui::Begin("Materials")` in `Application.cpp`
 - **Light types and GPU struct:** `Light.h` — must keep `GPULight` at 128 bytes and update GLSL struct to match
@@ -163,6 +172,7 @@ Image units and SSBO binding points are **separate namespaces**. `GL_MAX_IMAGE_U
 - **Render pipeline orchestration:** `Renderer.cpp`
 - **Event system:** `EventBus.h` (subscribe/publish), `Events.h` (event structs)
 - **Entity structure:** `Entity.h` (add new optional components here)
+- **Display texture selection for ImGui:** `Renderer::getDisplayTexture()` — returns `m_presentationTexture` when FXAA is enabled, else `m_outputTexture`. The viewport `ImGui::Image` call in `Application.cpp` goes through this getter
 
 ## Adding a New Shader
 
@@ -172,3 +182,13 @@ Image units and SSBO binding points are **separate namespaces**. `GL_MAX_IMAGE_U
 4. Bind SSBOs/images and dispatch in `Renderer::render()` at the correct phase
 5. Release in `Renderer::shutdown()`
 6. Shaders are auto-copied to the build output directory on rebuild
+
+## Adding a New ImGui Panel
+
+`Application.cpp` uses **ImGui docking** with an explicit layout built via `DockBuilderDockWindow` (search the `m_firstLoop` block — runs on every launch). A new `ImGui::Begin("X")` without a matching `DockBuilderDockWindow("X", ...)` becomes a free-floating window that often stacks behind others and looks missing.
+
+1. Add the panel with `ImGui::Begin("PanelName") / ImGui::End()` somewhere in the render loop.
+2. Add `ImGui::DockBuilderDockWindow("PanelName", dockRightBottom)` (or another node) to the initial dock layout block — the window title must match exactly.
+3. Viewport render targets are separate from the output texture in general; sample via `m_renderer.getDisplayTexture()` for anything that should respect post-process toggles.
+
+Resizeable viewport render targets must be re-created in `Renderer::resize()`; forgetting this will crash on window resize (see how `m_outputTexture` and `m_presentationTexture` are handled).

--- a/include/Renderer.h
+++ b/include/Renderer.h
@@ -41,11 +41,28 @@ public:
     void resize(int newWidth, int newHeight);
 
     GLuint getOutputTexture()  const { return m_outputTexture;  }
+    // Returns the texture ImGui should sample. When FXAA is enabled this is the
+    // post-processed presentation image; otherwise it's the raw pass5 output.
+    GLuint getDisplayTexture() const {
+        return m_fxaaEnabled ? m_presentationTexture : m_outputTexture;
+    }
     int    getViewportWidth()  const { return m_viewportWidth;  }
     int    getViewportHeight() const { return m_viewportHeight; }
 
     void setDebugMode(bool enabled) { m_debugMode = enabled; }
     bool getDebugMode()       const { return m_debugMode;    }
+
+    // --- FXAA (pass6_fxaa.comp) toggles ---
+    // When disabled the pass6 dispatch is skipped entirely and getDisplayTexture()
+    // falls back to the raw output, so the off state has zero GPU cost.
+    bool  getFXAAEnabled()          const { return m_fxaaEnabled;          }
+    void  setFXAAEnabled(bool e)          { m_fxaaEnabled = e;             }
+    float getFXAAQualitySubpix()    const { return m_fxaaQualitySubpix;    }
+    void  setFXAAQualitySubpix(float v)   { m_fxaaQualitySubpix = v;       }
+    float getFXAAEdgeThreshold()    const { return m_fxaaEdgeThreshold;    }
+    void  setFXAAEdgeThreshold(float v)   { m_fxaaEdgeThreshold = v;       }
+    float getFXAAEdgeThresholdMin() const { return m_fxaaEdgeThresholdMin; }
+    void  setFXAAEdgeThresholdMin(float v){ m_fxaaEdgeThresholdMin = v;    }
 
     LightManager&    getLightManager()    { return m_lightManager;    }
     MaterialManager& getMaterialManager() { return m_materialManager; }
@@ -70,6 +87,8 @@ private:
     // OIT composite pass: reads OIT accumulation SSBOs written by pass4 and blends
     // weighted transparent geometry over the opaque output image.
     std::unique_ptr<ComputeShader> m_pass5OITShader;
+    // FXAA post-process: samples m_outputTexture, writes m_presentationTexture.
+    std::unique_ptr<ComputeShader> m_pass6FXAAShader;
     std::unique_ptr<ComputeShader> m_debugTilesShader;
     // Shadow mapping shaders — clear the shadow map then rasterise scene depth from the light.
     std::unique_ptr<ComputeShader> m_clearShadowShader;
@@ -78,6 +97,10 @@ private:
     // Viewport render targets
     GLuint m_outputTexture  = 0;
     GLuint m_depthBuffer    = 0;
+    // FXAA destination. Separate from m_outputTexture so we never read+write the same
+    // texture through a sampler+image binding simultaneously. Shares format/filters/wrap
+    // with m_outputTexture (allocated through createOutputTexture()).
+    GLuint m_presentationTexture = 0;
     int    m_viewportWidth  = 256;
     int    m_viewportHeight = 256;
 
@@ -116,6 +139,12 @@ private:
 
     bool m_sceneDirty = true;   // safety net: auto-submit on first render if missed
     bool m_debugMode  = false;
+
+    // FXAA state. Defaults match FXAA 3.11 "PC Quality" presets.
+    bool  m_fxaaEnabled          = true;
+    float m_fxaaQualitySubpix    = 0.75f;   // [0, 1] subpixel blend strength
+    float m_fxaaEdgeThreshold    = 0.166f;  // local-contrast threshold
+    float m_fxaaEdgeThresholdMin = 0.0833f; // absolute dark cutoff
 };
 
 #endif // RENDERER_H

--- a/shaders/pass6_fxaa.comp
+++ b/shaders/pass6_fxaa.comp
@@ -1,0 +1,130 @@
+#version 430 core
+
+// pass6_fxaa.comp — Phase 5: Fast Approximate Anti-Aliasing (post-process).
+//
+// Runs after pass5's OIT composite. Samples the fully-composited scene (opaque + transparent)
+// from `srcImage` and writes an edge-smoothed result to `dstImage`. When FXAA is disabled on
+// the CPU side this dispatch is skipped entirely and the raw output is presented directly.
+//
+// This is a compact port of FXAA 3.11's "console quality" path:
+//   - 1 center + 4 N/E/S/W luma samples drive an early-out against a local-contrast threshold.
+//   - 4 diagonal samples feed edge-direction classification (horizontal vs vertical gradient).
+//   - A single offset tap along the detected edge normal is blended with the center by a
+//     subpixel-contrast weight. No iterative edge-walk — fast and divergence-light.
+//
+// Why a sampler2D (not image2D) for the source?
+//   FXAA leans on bilinear filtering for its half-pixel offset tap. Image loads are nearest
+//   only, so we bind the pass5 output to texture unit 0 (GL_LINEAR, GL_CLAMP_TO_EDGE) and
+//   fetch with texture()/textureOffset().
+//
+// Binding namespaces:
+//   texture sampler unit 0  -> srcImage
+//   image unit          0  -> dstImage  (separate namespace, no conflict)
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+// Source: scene color written by pass5 (RGBA32F, GL_LINEAR filtering).
+layout(binding = 0) uniform sampler2D srcImage;
+
+// Destination: presentation image sampled by ImGui.
+layout(rgba32f, binding = 0) uniform writeonly image2D dstImage;
+
+// Viewport dimensions. Inverse resolution is computed here to avoid adding a setVec2
+// helper to ComputeShader — the rest of the pipeline already passes screenSize as ivec2.
+uniform ivec2 screenSize;
+
+// Subpixel-contrast blend strength in [0, 1]. Higher values remove more sub-pixel aliasing
+// at the cost of softening fine detail. 0.75 matches FXAA's default.
+uniform float uQualitySubpix;
+
+// Relative local-contrast threshold. Any pixel whose luma range is below
+// max(uEdgeThresholdMin, lumaMax * uEdgeThreshold) is copied through unchanged.
+//   0.333 = too little  (misses real edges)
+//   0.166 = default     (balanced)
+//   0.125 = high quality
+//   0.063 = overkill    (smooths near-flat regions too)
+uniform float uEdgeThreshold;
+
+// Absolute dark-scene cutoff. Prevents FXAA from blurring faint noise in dark regions where
+// relative contrast would otherwise trip the threshold.
+//   0.0833 = default (fast)
+//   0.0625 = high quality
+//   0.0312 = very high quality (slower, amplifies faint gradients)
+uniform float uEdgeThresholdMin;
+
+// Rec.601 luma — cheaper than rec.709 and visually indistinguishable for AA purposes.
+float rgb2luma(vec3 c) {
+    return dot(c, vec3(0.299, 0.587, 0.114));
+}
+
+void main() {
+    ivec2 pix = ivec2(gl_GlobalInvocationID.xy);
+    if (pix.x >= screenSize.x || pix.y >= screenSize.y) return;
+
+    vec2 invRes = 1.0 / vec2(screenSize);
+    vec2 uv     = (vec2(pix) + 0.5) * invRes;
+
+    // --- Center + 4-tap cross for the early-out test ---
+    vec3 rgbM  = texture(srcImage, uv).rgb;
+    float lumaM = rgb2luma(rgbM);
+    float lumaN = rgb2luma(textureOffset(srcImage, uv, ivec2( 0,  1)).rgb);
+    float lumaS = rgb2luma(textureOffset(srcImage, uv, ivec2( 0, -1)).rgb);
+    float lumaE = rgb2luma(textureOffset(srcImage, uv, ivec2( 1,  0)).rgb);
+    float lumaW = rgb2luma(textureOffset(srcImage, uv, ivec2(-1,  0)).rgb);
+
+    float lumaMin = min(lumaM, min(min(lumaN, lumaS), min(lumaE, lumaW)));
+    float lumaMax = max(lumaM, max(max(lumaN, lumaS), max(lumaE, lumaW)));
+    float range   = lumaMax - lumaMin;
+
+    // Not an edge — pass through.
+    if (range < max(uEdgeThresholdMin, lumaMax * uEdgeThreshold)) {
+        imageStore(dstImage, pix, vec4(rgbM, 1.0));
+        return;
+    }
+
+    // --- Diagonals for edge-direction classification ---
+    float lumaNW = rgb2luma(textureOffset(srcImage, uv, ivec2(-1,  1)).rgb);
+    float lumaNE = rgb2luma(textureOffset(srcImage, uv, ivec2( 1,  1)).rgb);
+    float lumaSW = rgb2luma(textureOffset(srcImage, uv, ivec2(-1, -1)).rgb);
+    float lumaSE = rgb2luma(textureOffset(srcImage, uv, ivec2( 1, -1)).rgb);
+
+    // Sobel-like gradient magnitudes. A strong horizontal edge means luma changes fastest
+    // vertically between neighbours, so we step along the y axis, and vice versa.
+    float edgeH = abs(lumaNW + lumaNE - 2.0 * lumaN)
+                + 2.0 * abs(lumaW + lumaE - 2.0 * lumaM)
+                + abs(lumaSW + lumaSE - 2.0 * lumaS);
+    float edgeV = abs(lumaNW + lumaSW - 2.0 * lumaW)
+                + 2.0 * abs(lumaN + lumaS - 2.0 * lumaM)
+                + abs(lumaNE + lumaSE - 2.0 * lumaE);
+    bool horzEdge = edgeH >= edgeV;
+
+    // Step direction along the edge normal. Pick the steeper of the two neighbour gradients
+    // so we move toward the *higher-contrast* side — that's where the anti-aliased tap lives.
+    float stepSize = horzEdge ? invRes.y : invRes.x;
+    float luma1    = horzEdge ? lumaS : lumaW;
+    float luma2    = horzEdge ? lumaN : lumaE;
+    float grad1    = luma1 - lumaM;
+    float grad2    = luma2 - lumaM;
+    bool  steep1   = abs(grad1) >= abs(grad2);
+    float stepLen  = steep1 ? -stepSize : stepSize;
+
+    // --- Subpixel weight ---
+    // Compare the 3×3 low-frequency average to the center luma. Large deltas mean the
+    // center is a subpixel feature (thin detail / single-pixel stair step) that benefits
+    // from softer blending. smoothstep + square gives FXAA's characteristic falloff.
+    float lumaAvg = (1.0 / 12.0) * (
+        2.0 * (lumaN + lumaS + lumaE + lumaW) +
+        (lumaNW + lumaNE + lumaSW + lumaSE));
+    float subpix = clamp(abs(lumaAvg - lumaM) / range, 0.0, 1.0);
+    subpix = (subpix * subpix) * (3.0 - 2.0 * subpix);       // smoothstep
+    subpix = subpix * subpix * uQualitySubpix;
+
+    // --- Offset tap + blend ---
+    // Half a pixel along the step direction lets bilinear filtering blend two pixels on
+    // the high-contrast side for free — this is the core of FXAA's edge smoothing.
+    vec2 offset = horzEdge ? vec2(0.0, stepLen) : vec2(stepLen, 0.0);
+    vec3 rgbEdge = texture(srcImage, uv + offset * 0.5).rgb;
+
+    vec3 rgbFinal = mix(rgbM, rgbEdge, subpix);
+    imageStore(dstImage, pix, vec4(rgbFinal, 1.0));
+}

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -233,6 +233,7 @@ void Application::update() {
         ImGui::DockBuilderDockWindow("Lighting",          dockRightBottom); // Tabbed with Camera Settings
         ImGui::DockBuilderDockWindow("Materials",         dockRightBottom); // Tabbed with Camera Settings
         ImGui::DockBuilderDockWindow("Textures",          dockRightBottom); // Tabbed with Camera Settings
+        ImGui::DockBuilderDockWindow("Anti-Aliasing",     dockRightBottom); // Tabbed with Camera Settings
         ImGui::DockBuilderDockWindow("Mouse",             dockRightBottom); // Tabbed with Camera Settings
         ImGui::DockBuilderFinish(dockspaceId);
     }
@@ -309,7 +310,7 @@ void Application::update() {
         // --- Display compute output ---
         // UV coordinates (0,1) → (1,0) flip the V axis because OpenGL textures have origin
         // at bottom-left while ImGui's image origin is top-left.
-        ImGui::Image(static_cast<ImTextureID>(static_cast<uintptr_t>(m_renderer.getOutputTexture())),
+        ImGui::Image(static_cast<ImTextureID>(static_cast<uintptr_t>(m_renderer.getDisplayTexture())),
                      ImVec2(static_cast<float>(m_renderer.getViewportWidth()),
                             static_cast<float>(m_renderer.getViewportHeight())),
                      ImVec2(0, 1), ImVec2(1, 0));
@@ -674,6 +675,33 @@ void Application::update() {
                 m_selectedEntity = i; // Cross-select: clicking a light here selects it in the hierarchy
             ImGui::PopID();
         }
+    }
+    ImGui::End();
+
+    // =============================================
+    // ANTI-ALIASING WINDOW
+    // =============================================
+    ImGui::Begin("Anti-Aliasing");
+    {
+        bool fxaa = m_renderer.getFXAAEnabled();
+        if (ImGui::Checkbox("FXAA", &fxaa))
+            m_renderer.setFXAAEnabled(fxaa);
+
+        ImGui::BeginDisabled(!fxaa);
+        float subpix = m_renderer.getFXAAQualitySubpix();
+        if (ImGui::SliderFloat("Subpixel strength", &subpix, 0.0f, 1.0f, "%.2f"))
+            m_renderer.setFXAAQualitySubpix(subpix);
+
+        float edge = m_renderer.getFXAAEdgeThreshold();
+        if (ImGui::SliderFloat("Edge threshold", &edge, 0.063f, 0.333f, "%.3f"))
+            m_renderer.setFXAAEdgeThreshold(edge);
+
+        float edgeMin = m_renderer.getFXAAEdgeThresholdMin();
+        if (ImGui::SliderFloat("Edge threshold min", &edgeMin, 0.0312f, 0.0833f, "%.4f"))
+            m_renderer.setFXAAEdgeThresholdMin(edgeMin);
+        ImGui::EndDisabled();
+
+        ImGui::TextDisabled("Defaults: 0.75 / 0.166 / 0.0833");
     }
     ImGui::End();
 

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -122,6 +122,8 @@ bool Renderer::initialize(int viewportWidth, int viewportHeight) {
     m_pass4Shader      = std::make_unique<ComputeShader>("shaders/pass4_rasterize_tiled.comp");
     // OIT composite pass: blend transparent fragments over the opaque output image.
     m_pass5OITShader   = std::make_unique<ComputeShader>("shaders/pass5_oit_composite.comp");
+    // FXAA post-process (runs after pass5 when m_fxaaEnabled is true).
+    m_pass6FXAAShader  = std::make_unique<ComputeShader>("shaders/pass6_fxaa.comp");
     m_debugTilesShader = std::make_unique<ComputeShader>("shaders/debug_tiles.comp");
     // Shadow mapping shaders.
     m_clearShadowShader = std::make_unique<ComputeShader>("shaders/clear_shadow.comp");
@@ -130,7 +132,8 @@ bool Renderer::initialize(int viewportWidth, int viewportHeight) {
     if (!m_clearDepthShader->isValid()  || !m_clearTilesShader->isValid()  ||
         !m_pass1Shader->isValid()       || !m_pass2Shader->isValid()       ||
         !m_pass3Shader->isValid()       || !m_pass4Shader->isValid()       ||
-        !m_pass5OITShader->isValid()    || !m_debugTilesShader->isValid()  ||
+        !m_pass5OITShader->isValid()    || !m_pass6FXAAShader->isValid()   ||
+        !m_debugTilesShader->isValid()  ||
         !m_clearShadowShader->isValid() || !m_shadowPassShader->isValid()) {
         std::cerr << "[ERROR] Renderer: one or more compute shaders failed to compile" << std::endl;
         return false;
@@ -140,6 +143,9 @@ bool Renderer::initialize(int viewportWidth, int viewportHeight) {
     m_viewportHeight = viewportHeight;
     m_outputTexture  = createOutputTexture(viewportWidth, viewportHeight);
     m_depthBuffer    = createDepthBuffer(viewportWidth, viewportHeight);
+    // FXAA destination — same format/filter/wrap as m_outputTexture so bilinear fetches
+    // in pass6 behave identically regardless of which texture is sampled.
+    m_presentationTexture = createOutputTexture(viewportWidth, viewportHeight);
 
     // Shadow map is fixed-resolution, so it's created once here and never resized
     // in response to viewport changes.
@@ -172,9 +178,10 @@ bool Renderer::initialize(int viewportWidth, int viewportHeight) {
 // LightManager must be shut down before the GL context is destroyed (it owns an SSBO).
 // ComputeShader unique_ptrs reset here, calling their destructors and glDeleteProgram.
 void Renderer::shutdown() {
-    glDeleteTextures(1, &m_outputTexture);    m_outputTexture    = 0;
-    glDeleteTextures(1, &m_depthBuffer);      m_depthBuffer      = 0;
-    glDeleteTextures(1, &m_shadowMapTexture); m_shadowMapTexture = 0;
+    glDeleteTextures(1, &m_outputTexture);       m_outputTexture       = 0;
+    glDeleteTextures(1, &m_presentationTexture); m_presentationTexture = 0;
+    glDeleteTextures(1, &m_depthBuffer);         m_depthBuffer         = 0;
+    glDeleteTextures(1, &m_shadowMapTexture);    m_shadowMapTexture    = 0;
 
     // Release OIT accumulation SSBOs
     GLuint oitBufs[] = { m_oitAccumR, m_oitAccumG, m_oitAccumB, m_oitAccumA, m_oitReveal };
@@ -192,6 +199,7 @@ void Renderer::shutdown() {
     m_pass3Shader.reset();
     m_pass4Shader.reset();
     m_pass5OITShader.reset();
+    m_pass6FXAAShader.reset();
     m_debugTilesShader.reset();
     m_clearShadowShader.reset();
     m_shadowPassShader.reset();
@@ -207,11 +215,13 @@ void Renderer::shutdown() {
 void Renderer::resize(int newWidth, int newHeight) {
     glFinish(); // Wait for GPU to complete any ongoing compute dispatches
     glDeleteTextures(1, &m_outputTexture);
+    glDeleteTextures(1, &m_presentationTexture);
     glDeleteTextures(1, &m_depthBuffer);
     m_viewportWidth  = newWidth;
     m_viewportHeight = newHeight;
-    m_outputTexture  = createOutputTexture(newWidth, newHeight);
-    m_depthBuffer    = createDepthBuffer(newWidth, newHeight);
+    m_outputTexture       = createOutputTexture(newWidth, newHeight);
+    m_presentationTexture = createOutputTexture(newWidth, newHeight);
+    m_depthBuffer         = createDepthBuffer(newWidth, newHeight);
     // OIT buffers are per-pixel so they must match the new viewport dimensions exactly.
     createOITBuffers(newWidth, newHeight);
     if (!m_mergedMesh.faces.empty())
@@ -558,7 +568,39 @@ void Renderer::render(Scene& scene, const Camera& camera, const AssetManager& am
         glBindTexture(GL_TEXTURE_2D, 0);
     }
 
-    // GL_TEXTURE_FETCH_BARRIER_BIT ensures that imageStore writes from pass4 are visible
-    // when ImGui samples the texture with a texture fetch (glBindTexture / GLSL texture()).
+    // Sync image writes from pass5 / debug path so the following texture fetches see them.
+    // Required before pass6 samples m_outputTexture, and before ImGui samples whichever
+    // texture getDisplayTexture() returns when FXAA is disabled.
     glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL_TEXTURE_FETCH_BARRIER_BIT);
+
+    // --- Phase 5: FXAA (pass6_fxaa.comp) ---
+    // Post-process over the fully composited image. Reads m_outputTexture through a sampler
+    // (bilinear + clamp-to-edge, configured in createOutputTexture) and writes the smoothed
+    // result to m_presentationTexture. When disabled we skip the dispatch entirely and
+    // getDisplayTexture() returns m_outputTexture — zero GPU cost in the off state.
+    //
+    // Sampler unit 0 (srcImage) and image unit 0 (dstImage) occupy separate namespaces,
+    // so using binding slot 0 for both is legal and unambiguous.
+    if (m_fxaaEnabled) {
+        m_pass6FXAAShader->use();
+
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, m_outputTexture);
+        m_pass6FXAAShader->setInt("srcImage", 0);
+
+        glBindImageTexture(0, m_presentationTexture, 0, GL_FALSE, 0,
+                           GL_WRITE_ONLY, GL_RGBA32F);
+
+        m_pass6FXAAShader->setIVec2("screenSize",
+                                    glm::ivec2(m_viewportWidth, m_viewportHeight));
+        m_pass6FXAAShader->setFloat("uQualitySubpix",    m_fxaaQualitySubpix);
+        m_pass6FXAAShader->setFloat("uEdgeThreshold",    m_fxaaEdgeThreshold);
+        m_pass6FXAAShader->setFloat("uEdgeThresholdMin", m_fxaaEdgeThresholdMin);
+
+        m_pass6FXAAShader->dispatch(numGroupsX, numGroupsY, 1);
+
+        // pass6's imageStore into m_presentationTexture must be visible to ImGui's
+        // subsequent texture fetch.
+        glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT | GL_TEXTURE_FETCH_BARRIER_BIT);
+    }
 }


### PR DESCRIPTION
Adds pass6_fxaa.comp — a compact port of FXAA 3.11 "console quality" that samples the composited pass5 output and writes to a new presentation texture. The engine is compute-only, so hardware MSAA isn't available; FXAA was chosen over sub-pixel rasterisation and TAA because it costs a single extra dispatch and leaves pass4/pass5 untouched.

- shaders/pass6_fxaa.comp: 16×16 workgroup, sampler2D source (free bilinear), write-only image2D destination, single-offset-tap resolve with subpixel smoothstep blend and early-out on local contrast.
- Renderer owns m_presentationTexture (RGBA32F, same params as outputTexture) and re-creates it alongside outputTexture in resize().
- FXAA can be toggled at runtime; when off the dispatch is skipped and getDisplayTexture() returns the raw output — zero cost in the off state.
- New "Anti-Aliasing" ImGui panel (FXAA toggle + subpixel / edge thresholds), docked alongside Materials/Camera Settings via DockBuilderDockWindow.
- CLAUDE.md updated: pipeline table now covers phases 5 (FXAA) and 6 (display); new sections for pass6 bindings and "Adding a New ImGui Panel" (docking gotcha); build command switched to -p: form for Git Bash compatibility.